### PR TITLE
JENKINS-36377 Additional APIs for Blue Ocean autofavorite feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.447</version>
+        <version>2.17</version>
     </parent>
 
     <groupId>org.jvnet.hudson.plugins</groupId>
@@ -44,6 +44,16 @@
     </pluginRepositories>
 
     <dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>mailer</artifactId>
+            <version>1.18</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>matrix-project</artifactId>
+            <version>1.7.1</version>
+        </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>token-macro</artifactId>

--- a/src/main/java/hudson/plugins/favorite/Favorites.java
+++ b/src/main/java/hudson/plugins/favorite/Favorites.java
@@ -1,0 +1,131 @@
+package hudson.plugins.favorite;
+
+import com.google.inject.Singleton;
+import hudson.model.Item;
+import hudson.model.User;
+import hudson.plugins.favorite.user.FavoriteUserProperty;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+
+/**
+ * Public API for Favorites
+ */
+public final class Favorites {
+    /**
+     * Toggles the favorite for a job
+     * @param user that the favorite belongs to
+     * @param item to favorite
+     * @throws FavoriteException
+     * @return favorite state
+     */
+    public static boolean toggleFavorite(@Nonnull User user, @Nonnull Item item) throws FavoriteException {
+        try {
+            FavoriteUserProperty property = getProperty(user);
+            return property.toggleFavorite(item.getFullName());
+        } catch (IOException e) {
+            throw new FavoriteException("Could not determine Favorite state. User: <" + user.getFullName() + "> Item: <" + item.getFullName() + ">", e);
+        }
+    }
+
+    /**
+     * Check if the item is favorited
+     * @param user to check
+     * @param item to check
+     * @return favorite state
+     * @throws FavoriteException
+     */
+    public static boolean isFavorite(@Nonnull User user, @Nonnull Item item) throws FavoriteException {
+        try {
+            FavoriteUserProperty property = getProperty(user);
+            return property.isJobFavorite(item.getFullName());
+        } catch (IOException e) {
+            throw new FavoriteException("Could not determine Favorite state. User: <" + user.getFullName() + "> Item: <" + item.getFullName() + ">", e);
+        }
+    }
+
+    /**
+     * Check if the item has a favorite entry regardless of its state
+     * This is useful for checking if a favorite/unfavorite operation has ever been performed against this user
+     * @param user to check
+     * @param item to check
+     * @return favorite state
+     * @throws FavoriteException
+     */
+    public static boolean hasFavorite(@Nonnull User user, @Nonnull Item item) throws FavoriteException {
+        try {
+            FavoriteUserProperty property = getProperty(user);
+            return property.hasFavorite(item.getFullName());
+        } catch (IOException e) {
+            throw new FavoriteException("Could not determine Favorite state. User: <" + user.getFullName() + "> Item: <" + item.getFullName() + ">", e);
+        }
+    }
+
+    /**
+     * Add an item as a favorite for a user
+     * @param user to add the favorite to
+     * @param item to favorite
+     * @throws FavoriteException
+     */
+    public static void addFavorite(@Nonnull User user, @Nonnull Item item) throws FavoriteException {
+        try {
+            if (!isFavorite(user, item)) {
+                FavoriteUserProperty property = getProperty(user);
+                property.addFavorite(item.getFullName());
+            } else {
+                throw new FavoriteException("Favourite is already set for User: <" + user.getFullName() + "> Item: <" + item.getFullName() + ">");
+            }
+        } catch (IOException e) {
+            throw new FavoriteException("Could not add Favorite. User: <" + user.getFullName() + "> Item: <" + item.getFullName() + ">", e);
+        }
+    }
+
+    /**
+     * Add an item as a favorite for a user
+     * @param user to remove the favorite from
+     * @param item to favorite
+     * @throws FavoriteException
+     */
+    public static void removeFavorite(@Nonnull User user, @Nonnull Item item) throws FavoriteException {
+        try {
+            if (isFavorite(user, item)) {
+                FavoriteUserProperty fup = user.getProperty(FavoriteUserProperty.class);
+                fup.removeFavorite(item.getFullName());
+            } else {
+                throw new FavoriteException("Favourite is already unset for User: <" + user.getFullName() + "> Item: <" + item.getFullName() + ">");
+            }
+        } catch (IOException e) {
+            throw new FavoriteException("Could not remove Favorite. User: <" + user.getFullName() + "> Item: <" + item.getFullName() + ">", e);
+        }
+    }
+
+    /**
+     *
+     * @param user to get the property from
+     * @return favorite property
+     * @throws IOException if there is a problem with the user property
+     * @throws IllegalArgumentException when the user is anonymous
+     */
+    private static FavoriteUserProperty getProperty(@Nonnull User user) throws IOException {
+        if (FavoritePlugin.isAnonymous(user)) {
+            throw new IllegalArgumentException("user cannot be anonymous");
+        }
+        FavoriteUserProperty fup = user.getProperty(FavoriteUserProperty.class);
+        if (fup == null) {
+            user.addProperty(new FavoriteUserProperty());
+            fup = user.getProperty(FavoriteUserProperty.class);
+        }
+        return fup;
+    }
+
+    /** Exception for Favorite operations */
+    public static class FavoriteException extends Exception {
+        public FavoriteException(String message, Throwable cause) {
+            super(message, cause);
+        }
+
+        public FavoriteException(String message) {
+            super(message);
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/favorite/column/FavoriteColumn.java
+++ b/src/main/java/hudson/plugins/favorite/column/FavoriteColumn.java
@@ -7,6 +7,7 @@ import hudson.model.User;
 import hudson.plugins.favorite.Messages;
 import hudson.plugins.favorite.user.FavoriteUserProperty;
 import hudson.views.ListViewColumn;
+import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.acegisecurity.Authentication;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -50,7 +51,14 @@ public class FavoriteColumn extends ListViewColumn {
     private FavoriteUserProperty getFavoriteUserProperty() {
         Authentication authentication = Hudson.getAuthentication();
         String name = authentication.getName();
-        User user = Hudson.getInstance().getUser(name);
+        Jenkins jenkins = Jenkins.getInstance();
+        if (jenkins == null) {
+            throw new IllegalStateException("Jenkins not started");
+        }
+        User user = jenkins.getUser(name);
+        if (user == null) {
+            throw new IllegalStateException("Can't find user " + name);
+        }
         return user.getProperty(FavoriteUserProperty.class);
     }
 

--- a/src/main/java/hudson/plugins/favorite/filter/FavoriteFilter.java
+++ b/src/main/java/hudson/plugins/favorite/filter/FavoriteFilter.java
@@ -7,6 +7,7 @@ import hudson.model.User;
 import hudson.model.View;
 import hudson.plugins.favorite.user.FavoriteUserProperty;
 import hudson.views.ViewJobFilter;
+import jenkins.model.Jenkins;
 import org.acegisecurity.Authentication;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -27,7 +28,11 @@ public class FavoriteFilter extends ViewJobFilter {
 
         String name = authentication.getName();
         if (name != null && authentication.isAuthenticated()) {
-            User user = Hudson.getInstance().getUser(name);
+            Jenkins jenkins = Jenkins.getInstance();
+            if (jenkins == null) {
+                throw new IllegalStateException("Jenkins not started");
+            }
+            User user = jenkins.getUser(name);
             if (user != null) {
                 FavoriteUserProperty fup = user.getProperty(FavoriteUserProperty.class);
                 if (fup != null) {

--- a/src/main/java/hudson/plugins/favorite/listener/FavoriteJobListener.java
+++ b/src/main/java/hudson/plugins/favorite/listener/FavoriteJobListener.java
@@ -8,9 +8,13 @@ import hudson.model.listeners.ItemListener;
 import hudson.plugins.favorite.user.FavoriteUserProperty;
 
 import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 @Extension
 public class FavoriteJobListener extends ItemListener {
+
+  private final static Logger LOGGER = Logger.getLogger(FavoriteJobListener.class.getName());
 
   @Override
   public void onRenamed(Item item, String oldName, String newName) {
@@ -26,7 +30,7 @@ public class FavoriteJobListener extends ItemListener {
             }
           }
         } catch (IOException e) {
-          e.printStackTrace();
+          LOGGER.log(Level.SEVERE, "Could not migrate favourites from <" + oldName + "> to <" + newName + ">. Favourites have been lost for this item.", e);
         }
       }
     }
@@ -45,7 +49,7 @@ public class FavoriteJobListener extends ItemListener {
             }
           }
         } catch (IOException e) {
-          e.printStackTrace();
+          LOGGER.log(Level.WARNING, "Remove favourites deleted item <" + item.getFullName() + ">.", e);
         }
       }
     }

--- a/src/main/java/hudson/plugins/favorite/user/FavoriteUserPropertyDescriptor.java
+++ b/src/main/java/hudson/plugins/favorite/user/FavoriteUserPropertyDescriptor.java
@@ -29,8 +29,12 @@ public class FavoriteUserPropertyDescriptor extends UserPropertyDescriptor {
     }
 
     public AutoCompletionCandidates doAutoCompleteJob(@QueryParameter String value) {
+        Jenkins jenkins = Jenkins.getInstance();
+        if (jenkins == null) {
+            throw new IllegalStateException("Jenkins not started");
+        }
         AutoCompletionCandidates c = new AutoCompletionCandidates();
-        for (String job : Hudson.getInstance().getJobNames()) {
+        for (String job : jenkins.getJobNames()) {
             if (job.toLowerCase().startsWith(value.toLowerCase())) {
                 c.add(job);
             }
@@ -41,6 +45,9 @@ public class FavoriteUserPropertyDescriptor extends UserPropertyDescriptor {
     public Item toItem(String fullName) {
         if (StringUtils.isEmpty(fullName)) return null;
         ItemGroup<? extends Item> container = Jenkins.getInstance();
+        if (container == null) {
+            throw new IllegalStateException("Jenkins not started");
+        }
         int start = 0;
         int index = fullName.indexOf('/', start);
         while (index != -1) {

--- a/src/main/resources/hudson/plugins/favorite/column/FavoriteColumn/column.jelly
+++ b/src/main/resources/hudson/plugins/favorite/column/FavoriteColumn/column.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <j:if test="${it.isLoggedIn()}">

--- a/src/main/resources/hudson/plugins/favorite/column/FavoriteColumn/columnHeader.jelly
+++ b/src/main/resources/hudson/plugins/favorite/column/FavoriteColumn/columnHeader.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
     <j:if test="${it.isLoggedIn()}">
         <th>${%Fav}</th>

--- a/src/main/resources/hudson/plugins/favorite/user/FavoriteUserProperty/config.jelly
+++ b/src/main/resources/hudson/plugins/favorite/user/FavoriteUserProperty/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:block>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
   This plugin allows users to favorite a job.
 </div>

--- a/src/test/java/hudson/plugins/favorite/user/FavoriteUserPropertyTest.java
+++ b/src/test/java/hudson/plugins/favorite/user/FavoriteUserPropertyTest.java
@@ -1,0 +1,26 @@
+package hudson.plugins.favorite.user;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class FavoriteUserPropertyTest {
+    @Test
+    public void testMigration() throws Exception {
+        FavoriteUserProperty property = new FavoriteUserProperty();
+        property.favorites.add("foo");
+        property.favorites.add("bar");
+        property.favorites.add("baz");
+
+        assertFalse(property.hasFavorite("foo"));
+        assertFalse(property.hasFavorite("bar"));
+        assertFalse(property.hasFavorite("baz"));
+
+        property.readResolve();
+
+        assertTrue(property.hasFavorite("foo"));
+        assertTrue(property.hasFavorite("bar"));
+        assertTrue(property.hasFavorite("baz"));
+    }
+}

--- a/src/test/java/hudson/plugins/favorite/user/FavoritesTest.java
+++ b/src/test/java/hudson/plugins/favorite/user/FavoritesTest.java
@@ -1,0 +1,63 @@
+package hudson.plugins.favorite.user;
+
+import hudson.model.Item;
+import hudson.model.User;
+import hudson.plugins.favorite.Favorites;
+import hudson.plugins.favorite.Favorites.FavoriteException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.IOException;
+
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.fail;
+import static junit.framework.TestCase.assertFalse;
+
+public class FavoritesTest {
+    @Rule
+    public JenkinsRule rule = new JenkinsRule();
+
+    @Test
+    public void testToggleFavorite() throws FavoriteException, IOException {
+        User user = User.get("bob");
+        Item item = rule.createFreeStyleProject("bob");
+
+        assertFalse(Favorites.hasFavorite(user, item));
+        assertFalse(Favorites.isFavorite(user, item));
+
+        assertTrue(Favorites.toggleFavorite(user, item));
+        assertTrue(Favorites.hasFavorite(user, item));
+        assertTrue(Favorites.isFavorite(user, item));
+    }
+
+    @Test
+    public void testAddAndRemoveFavorite() throws FavoriteException, IOException {
+        User user = User.get("bob");
+        Item item = rule.createFreeStyleProject("bob");
+
+        assertFalse(Favorites.hasFavorite(user, item));
+        assertFalse(Favorites.isFavorite(user, item));
+
+        try {
+            Favorites.removeFavorite(user, item);
+            fail("Exception not thrown");
+        } catch (FavoriteException e) {}
+
+        assertFalse(Favorites.hasFavorite(user, item));
+        assertFalse(Favorites.isFavorite(user, item));
+
+        Favorites.addFavorite(user, item);
+        assertTrue(Favorites.hasFavorite(user, item));
+        assertTrue(Favorites.isFavorite(user, item));
+
+        try {
+            Favorites.addFavorite(user, item);
+            fail("Exception not thrown");
+        } catch (FavoriteException e) {}
+
+        Favorites.removeFavorite(user, item);
+        assertTrue(Favorites.hasFavorite(user, item));
+        assertFalse(Favorites.isFavorite(user, item));
+    }
+}


### PR DESCRIPTION
Needed for Blue Ocean's autofavorite feature. See [JENKINS-36377](https://issues.jenkins-ci.org/browse/JENKINS-36377).

Changes include:
* Add API to check if user has ever set a favourite for a job
* Add API to toggle favourite
* Bump base POM
* Fix findbugs issues

PTAL @imeredith @larrys