### PR TITLE
Fix Build for Favorites.java for java.util.Iterator missing remove()

### DIFF
--- a/src/main/java/hudson/plugins/favorite/Favorites.java
+++ b/src/main/java/hudson/plugins/favorite/Favorites.java
@@ -136,6 +136,12 @@ public final class Favorites {
                     public Item next() {
                         return jenkins.getItemByFullName(iterator.next());
                     }
+                    
+                    /* Fix build. */
+                    @Override
+                    public void remove() { 
+                        throw new UnsupportedOperationException(); 
+                    }
                 }, Predicates.<Item>notNull());
             }
         };


### PR DESCRIPTION
As mentioned in #6 fix for `Favorites.java` because
the Jenkins build fails.

**SEE: http://stackoverflow.com/a/5425148**