### PR TITLE
Add OpenSource License to Project (LICENSE.md)

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,1 @@
+TO BE DONE

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,1 +1,9 @@
-TO BE DONE
+# The MIT License (MIT)
+
+Copyright (c) `2016` `Larry Shatzer, Jr., James Dumay, Damien Finck, and other contributors`
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
@i386 and @larrys 

I pledge for `MIT License`and found the following parts which contain MIT License blocks:

https://github.com/jenkinsci/favorite-plugin/blob/master/src/main/resources/hudson/plugins/favorite/Messages_fr.properties
```

# The MIT License
#
# Copyright (c) 2014, Damien Finck
```

**Suggestion** so maybe just add all contributors to main MIT License file as authors?