### PR TITLE
[JENKINS-39990] fix Exceptions on user config page

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,26 @@ Remember to clean the `work` dir if something strange is happening, like plugin 
 rm -rf work/*
 ```
 
+### Pre Release Tests
+ 
+ **Testcase 1: Favorite Column on Job List Page**
+ 
+  * You are on the Job List Page and have created at least one Build Job.
+  * On the right a column 'Fav' needs to show up and show a grey star for the job.
+  * With a click on the grey star the star turns golden and the job is added as favorite.
+  * Preview: 
+    * ![testcase-1-favorite-column](https://cloud.githubusercontent.com/assets/12599965/20640106/2d7b5094-b3d6-11e6-8623-180056acb82d.gif)
+ 
+ 
+ **Testcase 2: Favorite Entries on User Config Page**
+ 
+  * On the Jenkins Start Page click on the small arrow right to your username in the top right corner.
+  * In the appearing dropdown click on configure.
+  * When scrolling down to 'Favorites' section you will see all your favorites.
+  * When clicking the golden star you can remove a job as favorite.
+  * Preview:
+    * ![testcase-2-favorite-config](https://cloud.githubusercontent.com/assets/12599965/20640200/f0c3b806-b3d7-11e6-9fd9-43a2676b0dc8.gif)
+ 
 ## License
 
 to be done

--- a/src/main/java/hudson/plugins/favorite/assets/Asset.java
+++ b/src/main/java/hudson/plugins/favorite/assets/Asset.java
@@ -1,0 +1,8 @@
+package hudson.plugins.favorite.assets;
+
+/**
+ * Just a dummy class for the jelly st:include which otherwise throws exceptions
+ * in config.jelly when st:include to css.jelly is called without class parameter
+ */
+public class Asset {
+}

--- a/src/main/java/hudson/plugins/favorite/user/FavoriteUserProperty.java
+++ b/src/main/java/hudson/plugins/favorite/user/FavoriteUserProperty.java
@@ -8,6 +8,7 @@ import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.model.UserProperty;
 import hudson.model.UserPropertyDescriptor;
+import hudson.plugins.favorite.assets.Asset;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
@@ -127,5 +128,9 @@ public class FavoriteUserProperty extends UserProperty {
             favorites = null;
         }
         return this;
+    }
+
+    public Class getAssetClass() {
+        return Asset.class;
     }
 }

--- a/src/main/resources/hudson/plugins/favorite/user/FavoriteUserProperty/config.jelly
+++ b/src/main/resources/hudson/plugins/favorite/user/FavoriteUserProperty/config.jelly
@@ -1,8 +1,8 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <st:include page="/hudson/plugins/favorite/assets/css.jelly" />
-  <st:include page="/hudson/plugins/favorite/assets/javascript.jelly" />
+  <st:include page="/hudson/plugins/favorite/assets/css.jelly" class="${instance.assetClass}" />
+  <st:include page="/hudson/plugins/favorite/assets/javascript.jelly" class="${instance.assetClass}" />
   <f:block>
     <table id="favorites">
       <j:forEach var="favorite" items="${instance.favorites}">


### PR DESCRIPTION
@i386 the fix for [JENKINS-39990](https://issues.jenkins-ci.org/browse/JENKINS-39990).

I also added some Pre-Release-Test documentation so that the next one who releases also knows what to test. You can see it here: https://github.com/clouless/favorite-plugin/tree/fix-JENKINS-39990-2#pre-release-tests

About the Fix: Somehow a `<st:include` always uses a class as context which seems to be the User.class from jenkins. And since that class is inside Jenkins and out of the scope of the plugin it seems the path to the css.jelly cannot be found. Therefore a "dummy" class called `Asset.java` is used and passed to the `<st:include` to tell the Stapler to include the `css.jelly` and `javascript.jelly` without any other class scope and from the favorite plugin scope.