### PR TITLE
Added a licensing definition to the Maven project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,15 @@
     <packaging>hpi</packaging>
 
     <name>Favorite</name>
-    <url>http://wiki.jenkins-ci.org/display/JENKINS/Favorite+Plugin</url>
+    <url>https://wiki.jenkins.io/display/JENKINS/Favorite+Plugin</url>
+
+    <licenses>
+       <license>
+          <name>MIT License</name>
+          <url>https://opensource.org/licenses/MIT</url>
+          <distribution>repo</distribution>
+       </license>
+    </licenses>
 
     <developers>
         <developer>


### PR DESCRIPTION
In order to meet the [prerequisites](https://wiki.jenkins.io/display/JENKINS/Hosting+Plugins#HostingPlugins-Prerequisites) of plugin hosting in the Jenkins Organization, I'm adding the licensing definition in the Maven project.

@reviewbybees 