### PR TITLE
[JENKINS-48136] Encode job name for special character support

### DIFF
--- a/src/main/resources/hudson/plugins/favorite/assets.js
+++ b/src/main/resources/hudson/plugins/favorite/assets.js
@@ -1,5 +1,5 @@
 function toggleFavorite(job, a) {
-  new Ajax.Request(rootURL + "/plugin/favorite/toggleFavorite?job=" + job, {method: 'POST'});
+  new Ajax.Request(rootURL + "/plugin/favorite/toggleFavorite?job=" + encodeURIComponent(job), {method: 'POST'});
   var favIcon = document.getElementById("fav_" + job);
   if (favIcon.classList.contains("icon-fav-inactive")) {
     favIcon.classList.add("icon-fav-active");


### PR DESCRIPTION
URI encoded characters (such as forward slashes) were decoded when they should not be, preventing jobs with such characters in their names from being manually added/removed from the favorites list. These jobs have `%2F` in their names, which was decoded to `/`.

Fixes JENKINS-48136.