### PR TITLE
Replace Prototype.js with native JavaScript

### DIFF
--- a/src/main/resources/hudson/plugins/favorite/assets.js
+++ b/src/main/resources/hudson/plugins/favorite/assets.js
@@ -1,5 +1,8 @@
 function toggleFavorite(job, a) {
-  new Ajax.Request(rootURL + "/plugin/favorite/toggleFavorite?job=" + encodeURIComponent(job), {method: 'POST'});
+  fetch(rootURL + "/plugin/favorite/toggleFavorite?job=" + encodeURIComponent(job), {
+    method: 'post',
+    headers: crumb.wrap({}),
+  });
   var favIcon = document.getElementById("fav_" + job);
   if (favIcon.classList.contains("icon-fav-inactive")) {
     favIcon.classList.add("icon-fav-active");


### PR DESCRIPTION
See [JENKINS-70906](https://issues.jenkins.io/browse/JENKINS-70906). Jenkins core currently uses [Prototype 1.7](https://github.com/prototypejs/prototype/releases/tag/1.7), released on November 15, 2010. The latest version is [Prototype 1.7.3](https://github.com/prototypejs/prototype/releases/tag/1.7.3), released on September 22, 2015. When an attempt was made to upgrade to 1.7.3 in 2018 in [JENKINS-49319](https://issues.jenkins.io/browse/JENKINS-49319), the change had to be reverted. Since this library has been unmaintained for the past 8 years, this PR removes any usages of it in favor of native JavaScript APIs. To test this, I exercised the changed lines in my browser with a debugger and verified the new code correctly posted and could enable and disable a favorite.