### PR TITLE
[JENKINS-72345] fix FavoriteListener

### DIFF
--- a/src/main/java/hudson/plugins/favorite/Favorites.java
+++ b/src/main/java/hudson/plugins/favorite/Favorites.java
@@ -28,7 +28,13 @@ public final class Favorites {
     public static boolean toggleFavorite(@NonNull User user, @NonNull Item item) throws FavoriteException {
         try {
             FavoriteUserProperty property = getProperty(user);
-            return property.toggleFavorite(item.getFullName());
+            boolean result = property.toggleFavorite(item.getFullName());
+            if (result) {
+                FavoriteListener.fireOnAddFavourite(item, user);
+            } else {
+                FavoriteListener.fireOnRemoveFavourite(item, user);
+            }
+            return result;
         } catch (IOException e) {
             throw new FavoriteException("Could not determine Favorite state. User: <" + user.getFullName() + "> Item: <" + item.getFullName() + ">", e);
         }

--- a/src/main/java/hudson/plugins/favorite/listener/FavoriteListener.java
+++ b/src/main/java/hudson/plugins/favorite/listener/FavoriteListener.java
@@ -43,6 +43,16 @@ public abstract class FavoriteListener implements ExtensionPoint {
         }
     }
 
+    public static void fireOnLocationChangedFavorite(Item item, User user, String oldName, String newName) {
+        for (FavoriteListener listener : all()) {
+            try {
+                listener.onLocationChangedFavorite(item, user, oldName, newName);
+            } catch (Throwable e) {
+                LOGGER.log(Level.WARNING, "There was a problem firing listener " + listener.getClass().getName(), e);
+            }
+        }
+    }
+
     /**
      * Fired when a favorite has been addedfor the user
      * @param item that was favourited
@@ -56,4 +66,13 @@ public abstract class FavoriteListener implements ExtensionPoint {
      * @param user that the favorite was recorded for
      */
     public abstract void onRemoveFavourite(Item item, User user);
+
+    /**
+     * Fired when a favorite has been renamed/moved for the user
+     * @param item that was renamed/moved
+     * @param user that the favorite was recorded for
+     * @param oldName of the favorite
+     * @param newName of the favorite
+     */
+    public void onLocationChangedFavorite(Item item, User user, String oldName, String newName) {}
 }

--- a/src/main/java/hudson/plugins/favorite/user/FavoriteJobListener.java
+++ b/src/main/java/hudson/plugins/favorite/user/FavoriteJobListener.java
@@ -6,6 +6,7 @@ import hudson.model.Item;
 import hudson.model.User;
 import hudson.model.listeners.ItemListener;
 
+import hudson.plugins.favorite.listener.FavoriteListener;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -16,7 +17,7 @@ public class FavoriteJobListener extends ItemListener {
   private final static Logger LOGGER = Logger.getLogger(FavoriteJobListener.class.getName());
 
   @Override
-  public void onRenamed(Item item, String oldName, String newName) {
+  public void onLocationChanged(Item item, String oldName, String newName) {
     if (item instanceof AbstractProject<?, ?>) {
       for (User user : User.getAll()) {
         FavoriteUserProperty fup = user.getProperty(FavoriteUserProperty.class);
@@ -24,6 +25,7 @@ public class FavoriteJobListener extends ItemListener {
           if (fup != null && fup.isJobFavorite(oldName)) {
             fup.deleteFavourite(oldName);
             fup.addFavorite(newName);
+            FavoriteListener.fireOnLocationChangedFavorite(item, user, oldName, newName);
           }
         } catch (IOException e) {
           LOGGER.log(Level.SEVERE, "Could not migrate favourites from <" + oldName + "> to <" + newName + ">. Favourites have been lost for this item.", e);

--- a/src/main/java/hudson/plugins/favorite/user/FavoriteJobListener.java
+++ b/src/main/java/hudson/plugins/favorite/user/FavoriteJobListener.java
@@ -1,7 +1,6 @@
 package hudson.plugins.favorite.user;
 
 import hudson.Extension;
-import hudson.model.AbstractProject;
 import hudson.model.Item;
 import hudson.model.TopLevelItem;
 import hudson.model.User;

--- a/src/main/java/hudson/plugins/favorite/user/FavoriteJobListener.java
+++ b/src/main/java/hudson/plugins/favorite/user/FavoriteJobListener.java
@@ -3,6 +3,7 @@ package hudson.plugins.favorite.user;
 import hudson.Extension;
 import hudson.model.AbstractProject;
 import hudson.model.Item;
+import hudson.model.TopLevelItem;
 import hudson.model.User;
 import hudson.model.listeners.ItemListener;
 
@@ -18,7 +19,7 @@ public class FavoriteJobListener extends ItemListener {
 
   @Override
   public void onLocationChanged(Item item, String oldName, String newName) {
-    if (item instanceof AbstractProject<?, ?>) {
+    if (item instanceof TopLevelItem) {
       for (User user : User.getAll()) {
         FavoriteUserProperty fup = user.getProperty(FavoriteUserProperty.class);
         try {


### PR DESCRIPTION
the FavoriteListener should be called also when a favorite is toggled from a view or by clicking on the link in the sidebar. Also add a listener method that reacts when the location of a job changes.
Fix the FavoriteJobListener to react on location changes

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
